### PR TITLE
Packed fmat - use AVX and 256 bit wide vectors

### DIFF
--- a/src/gf.hh
+++ b/src/gf.hh
@@ -112,6 +112,47 @@ public:
     }
 
 #if GF2_bits == 16
+    __m256i wide_mul(__m256i a, __m256i b)
+    {
+        __m256i prod = _mm256_unpacklo_epi64(
+            _mm256_clmulepi64_epi128(a, b, 0x00),
+            _mm256_clmulepi64_epi128(a, b, 0x11)
+        );
+
+        __m256i lo = _mm256_and_si256(
+            prod,
+            _mm256_maskz_set1_epi16(0x1111, 0xFF)
+        );
+        __m256i hi = _mm256_slli_epi32(
+            prod,
+            16 // GF2_bits
+        );
+
+        __m256i tmp = _mm256_xor_si256(
+            hi,
+            _mm256_xor_si256(
+                _mm256_srli_epi16(hi, 14),
+                _mm256_xor_si256(
+                    _mm256_srli_epi16(hi, 13),
+                    _mm256_srli_epi16(hi, 11)
+                )
+            )
+        );
+
+        __m256i rem = _mm256_xor_si256(
+            tmp,
+            _mm256_xor_si256(
+                _mm256_slli_epi16(tmp, 2),
+                _mm256_xor_si256(
+                    _mm256_slli_epi16(tmp, 3),
+                    _mm256_slli_epi16(tmp, 5)
+                )
+            )
+        );
+
+        return _mm256_xor_si256(rem, lo);
+    }
+
     uint64_t packed_rem(uint64_t a) const
     {
         uint64_t pack_mask = this->mask | (this->mask << 32);

--- a/src/gf.hh
+++ b/src/gf.hh
@@ -121,9 +121,9 @@ public:
 
         __m256i lo = _mm256_and_si256(
             prod,
-            _mm256_maskz_set1_epi16(0x1111, 0xFF)
+            _mm256_maskz_set1_epi16(0x1111, 0xFFFF)
         );
-        __m256i hi = _mm256_slli_epi32(
+        __m256i hi = _mm256_srli_epi32(
             prod,
             16 // GF2_bits
         );

--- a/src/packed_fmatrix.hh
+++ b/src/packed_fmatrix.hh
@@ -3,6 +3,7 @@
 #define P_FMATRIX_H
 
 #include <valarray>
+#include <vector>
 #include <immintrin.h>
 
 #include "gf.hh"
@@ -59,7 +60,7 @@ private:
     int cols;
     // original matrix n moduloe VECTOR_N
     int nmod;
-    std::valarray<__m256i> m;
+    std::vector<__m256i> m;
 
     __m256i get(int row, int col)
     {

--- a/src/packed_fmatrix.hh
+++ b/src/packed_fmatrix.hh
@@ -71,7 +71,7 @@ private:
         this->m[row*this->cols + col] = v;
     }
 
-    __m256i gf_mul(__m256i a, __m256i b)//done
+    __m256i gf_mul(__m256i a, __m256i b)
     {
         __m256i prod = _mm256_unpacklo_epi64(
             _mm256_clmulepi64_epi128(a, b, 0x00),
@@ -115,7 +115,7 @@ private:
 
 
 public:
-    Packed_FMatrix(//done
+    Packed_FMatrix(
         const FMatrix &matrix
     )
     {
@@ -151,17 +151,17 @@ public:
             switch (r % VECTOR_N)
             {
             case 1:
-                idx = _mm256_set_epi_64x(
+                idx = _mm256_set_epi64x(
                     0, 1, 0, 0
                 );
                 break;
             case 2:
-                idx = _mm256_set_epi_64x(
+                idx = _mm256_set_epi64x(
                     0, 0, 1, 0
                 );
                 break;
             case 3:
-                idx = _mm256_set_epi_64x(
+                idx = _mm256_set_epi64x(
                     0, 0, 0, 1
                 );
                 break;
@@ -170,7 +170,7 @@ public:
         }
     }
 
-    void handle_gamma_zero(int r1, int r2) // done
+    void handle_gamma_zero(int r1, int r2)
     {
         // first 64 ones, rest zeros
         __m256i mask = _mm256_maskz_set1_epi32(
@@ -206,7 +206,7 @@ public:
         this->set(r1, this->cols - 1, _mm256_setzero_si256());
     }
 
-    void mul_gamma(int r1, int r2, const GF_element &gamma) // done
+    void mul_gamma(int r1, int r2, const GF_element &gamma)
     {
         /* alternative approach: do multiplications only in one direction
          * and then in the other direction use shuffle and shift them around
@@ -255,9 +255,9 @@ public:
             gamma_inv
         );
         /* fix edge case of orig n not dividing 4 */
-        if (this->modn)
+        if (this->nmod)
         {
-            for (int i = 0; i < VECTOR_N - this->modn; i++)
+            for (int i = 0; i < VECTOR_N - this->nmod; i++)
                 prod = this->gf_mul(prod, pac_gamma_inv);
         }
         pac_gamma_inv = this->gf_mul(pac_gamma_inv, pac_gamma_inv);
@@ -326,8 +326,8 @@ public:
         {
             DET_LOOP(0);
             DET_LOOP(1);
+            DET_LOOP(2);
             DET_LOOP(3);
-            DET_LOOP(4);
         }
         return GF_element(det);
     }
@@ -342,13 +342,13 @@ public:
             for (int col = 0; col < this->cols; col++)
             {
                 unpacked[row*this->rows + VECTOR_N*col + 0] =
-                    GF_element(_mm_extract_epi64(this->get(row, col), 3));
+                    GF_element(_mm256_extract_epi64(this->get(row, col), 3));
                 unpacked[row*this->rows + VECTOR_N*col + 1] =
-                    GF_element(_mm_extract_epi64(this->get(row, col), 2));
+                    GF_element(_mm256_extract_epi64(this->get(row, col), 2));
                 unpacked[row*this->rows + VECTOR_N*col + 2] =
-                    GF_element(_mm_extract_epi64(this->get(row, col), 1));
+                    GF_element(_mm256_extract_epi64(this->get(row, col), 1));
                 unpacked[row*this->rows + VECTOR_N*col + 3] =
-                    GF_element(_mm_extract_epi64(this->get(row, col), 0));
+                    GF_element(_mm256_extract_epi64(this->get(row, col), 0));
             }
         }
 

--- a/tests/unit/gf_test.cc
+++ b/tests/unit/gf_test.cc
@@ -1,5 +1,6 @@
 /* Copyright 2022 Eetu Karppinen. Subject to the MIT license. */
 #include <iostream>
+#include <immintrin.h>
 
 #include "gf_test.hh"
 #include "../../src/gf.hh"
@@ -129,6 +130,45 @@ void GF_test::test_packed_rem()
         );
 
         if (ref != r)
+            err++;
+    }
+    this->end_test(err);
+}
+
+void GF_test::test_wide_mul()
+{
+#define WIDTH 4
+    cout << "wide mul: ";
+    int err = 0;
+    for (int i = 0; i < this->tests / WIDTH; i++)
+    {
+        uint64_t a[WIDTH];
+        uint64_t b[WIDTH];
+        uint64_t prod[WIDTH];
+
+        for (int j = 0; j < WIDTH; j++)
+        {
+            a[j] = global::randgen() & global::F.get_mask();
+            b[j] = global::randgen() & global::F.get_mask();
+            prod[j] = global::F.rem(
+                global::F.clmul(a[j], b[j])
+            );
+        }
+
+        __m256i aa = _mm256_set_epi64x(a[3], a[2], a[1], a[0]);
+        __m256i bb = _mm256_set_epi64x(b[3], b[2], b[1], b[0]);
+        __m256i pp = global::F.wide_mul(aa, bb);
+
+        if (prod[0] != _mm256_extract_epi64(pp, 0))
+            err++;
+
+        if (prod[1] != _mm256_extract_epi64(pp, 1))
+            err++;
+
+        if (prod[2] != _mm256_extract_epi64(pp, 2))
+            err++;
+
+        if (prod[3] != _mm256_extract_epi64(pp, 3))
             err++;
     }
     this->end_test(err);

--- a/tests/unit/gf_test.hh
+++ b/tests/unit/gf_test.hh
@@ -16,6 +16,7 @@ private:
     void test_lift_project();
 #if GF2_bits == 16
     void test_packed_rem();
+    void test_wide_mul();
 #endif
 
     void run()
@@ -27,6 +28,7 @@ private:
         test_lift_project();
 #if GF2_bits == 16
         test_packed_rem();
+        test_wide_mul();
 #endif
     }
 


### PR DESCRIPTION
Implementes packed fmatrix with 256 bit wide vectors using AVX instructions (including _mm256_clmulepi64_epi128, thus AVX512 is required).